### PR TITLE
Add 'numeric' mssql type

### DIFF
--- a/cmd/sqlpipe/system_mssql.go
+++ b/cmd/sqlpipe/system_mssql.go
@@ -158,6 +158,8 @@ func (system Mssql) driverTypeToPipeType(
 		return "float32", nil
 	case "DECIMAL":
 		return "decimal", nil
+	case "NUMERIC":
+		return "decimal", nil
 	case "MONEY":
 		return "money", nil
 	case "SMALLMONEY":
@@ -212,6 +214,8 @@ func (system Mssql) dbTypeToPipeType(
 	case "real":
 		return "float32", nil
 	case "decimal":
+		return "decimal", nil
+	case "numeric":
 		return "decimal", nil
 	case "money":
 		return "money", nil


### PR DESCRIPTION
I'm working on a migration from mssql to Oracle.

Our database has a lot of 'numeric' columns, which are not handled by sqlpipe. Even though I know nothing about go, I tried to make a small change to add that data type. It works for my use case, so I thought of making a pull request. Fell free to reject it if it is incomplete or is basically wrong.

Thanks.