### PR TITLE
decimal to real mapping instead of numeric

### DIFF
--- a/cmd/sqlpipe/system_snowflake.go
+++ b/cmd/sqlpipe/system_snowflake.go
@@ -143,7 +143,7 @@ func (system Snowflake) pipeTypeToCreateType(
 	case "float32":
 		return "real", nil
 	case "decimal":
-		return "number", nil
+		return "real", nil
 	case "money":
 		return "number", nil
 	case "datetime":


### PR DESCRIPTION
I've updated the type mapping for decimal from number to real.
This change makes the handling of decimal types consistent with real. Using real is more appropriate for floating-point values and ensures that both types are treated similarly by the downstream system.